### PR TITLE
Q-libcurl-alt.md: add hyper/reqwest alternative

### DIFF
--- a/Q-libcurl-alt.md
+++ b/Q-libcurl-alt.md
@@ -10,6 +10,7 @@ libcurl's primary competitors for your use case
 - asio
 - cpp-netlib
 - homegrown
+- hyper/reqwest
 - libsoup
 - Mac OS/iOS native libs
 - native lib in Perl, Python, Java, Go, Rust, JavaScript etc


### PR DESCRIPTION
They were added in text several times in the 2025 survey